### PR TITLE
Added missing dash to collect switch

### DIFF
--- a/NetCoreSampleForCC/readme.md
+++ b/NetCoreSampleForCC/readme.md
@@ -10,7 +10,7 @@ Introducing code coverage for tests targeting .Net Core (Windows). Refer the fol
     1. Create a directory. Example: D:\sample-projects\sample.Tests and "cd" to it.
     2. `dotnet new mstest`
     3. `dotnet add package Microsoft.NET.Test.SDK --version 15.8.0-preview-20180610-02`
-    4. `dotnet test –collect “Code coverage”`
+    4. `dotnet test –-collect “Code coverage”`
     5. Open .coverage file in VS Enterprise to see the coverage info.
 
 ### On the solution in this repo (MSTestV2 + xUnit.net + NUnit)


### PR DESCRIPTION
I fixed what I think is a samll typo, because if I only use one dash with the collect switch I get the following error:

```
MSBUILD : error MSB1001: Unknown switch.
Switch: -collect

For switch syntax, type "MSBuild /help"
```